### PR TITLE
Update clap to 2.34

### DIFF
--- a/crx2rnx/Cargo.toml
+++ b/crx2rnx/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 
 [dependencies]
 rinex = { path = "../rinex", features = ["with-serde"] }
-clap = { version = "~2.27.0", features = ["yaml"] }
+clap = { version = "~2.34.0", features = ["yaml"] }
 thiserror = "1"
 
 [dev-dependencies]

--- a/rinex-cli/Cargo.toml
+++ b/rinex-cli/Cargo.toml
@@ -14,5 +14,5 @@ readme = "README.md"
 chrono = "0.4"
 serde_json = "1"
 rinex = { path = "../rinex", features = ["with-serde"] }
-clap = { version = "~2.27.0", features = ["yaml"] }
+clap = { version = "~2.34.0", features = ["yaml"] }
 gnuplot = "0.0.37"

--- a/ublox-rnx/Cargo.toml
+++ b/ublox-rnx/Cargo.toml
@@ -18,4 +18,4 @@ serialport = "4.2.0"
 #ublox = "0.4.2"
 ublox = { git = "https://github.com/gwbres/ublox", branch = "gwbr/develop" }
 rinex = { path = "../rinex", features = ["with-serde"] }
-clap = { version = "~2.27.0", features = ["yaml"] }
+clap = { version = "~2.34.0", features = ["yaml"] }


### PR DESCRIPTION
I noticed that a rather old version of clap is being used currently, in crx2rnx, ublox-rnx and rinex-cli.

Version 3 has [many breaking changes](https://github.com/clap-rs/clap/blob/master/CHANGELOG.md#300---2021-12-31), so I thought of bumping to 2.34 for now.