### PR TITLE
Let `sinex` use the current version of `rinex`

### DIFF
--- a/sinex/Cargo.toml
+++ b/sinex/Cargo.toml
@@ -20,4 +20,4 @@ chrono = "0.4"
 thiserror = "1"
 strum = { version = "0.24", features = ["derive"] }
 strum_macros = "0.24"
-rinex = "0.3.3"
+rinex = { path = "../rinex", features = ["with-serde"] }


### PR DESCRIPTION
Moving from 0.3.3 to the local version like the other tools