### PR TITLE
Ignore this cargo audit warning - it is not a problem

### DIFF
--- a/.github/workflows/Audit.yml
+++ b/.github/workflows/Audit.yml
@@ -17,4 +17,4 @@ jobs:
     - name: Audit
       run: |
         cargo install cargo-audit
-        cargo audit
+        cargo audit --ignore RUSTSEC-2020-007


### PR DESCRIPTION
The time/chrono RUSTSEC advisories can be effectively ignored, as they do not pose a real threat.