### PR TITLE
Set minimum Rust version to 1.61

### DIFF
--- a/rinex/Cargo.toml
+++ b/rinex/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["rinex", "timing", "gps", "glonass", "galileo"]
 categories = ["science", "parsing"]
 edition = "2018"
 readme = "README.md"
-
+rust-version = "1.61"
 [features]
 # no features by default
 default = []


### PR DESCRIPTION
Required to use the `vec_retain_mut` feature.

Fixes #17 