### PR TITLE
Remove exception from `cargo audit`

### DIFF
--- a/.github/workflows/Audit.yml
+++ b/.github/workflows/Audit.yml
@@ -17,4 +17,4 @@ jobs:
     - name: Audit
       run: |
         cargo install cargo-audit
-        cargo audit --ignore RUSTSEC-2020-007
+        cargo audit


### PR DESCRIPTION
The audit no longer gives a failed result upon a CVE, and the check was wrong anyway (was RUSTSEC-2020-007, should have been RUSTSEC-2020-0071)