### PR TITLE
Update Rust edition to 2021

### DIFF
--- a/crx2rnx/Cargo.toml
+++ b/crx2rnx/Cargo.toml
@@ -7,7 +7,7 @@ description = "RINEX data decompressor"
 homepage = "https://github.com/gwbres/rinex"
 keywords = ["rinex", "compression", "decompression", "crinex"] 
 categories = ["science", "command-line-interface", "command-line-utilities"]
-edition = "2018"
+edition = "2021"
 readme = "README.md"
 
 [dependencies]

--- a/rinex-cli/Cargo.toml
+++ b/rinex-cli/Cargo.toml
@@ -7,7 +7,7 @@ description = "Command line tool parse and analyze RINEX data"
 homepage = "https://github.com/gwbres/rinex"
 keywords = ["rinex", "gps", "glonass", "galileo", "timing"]
 categories = ["science", "command-line-interface", "command-line-utilities"]
-edition = "2018"
+edition = "2021"
 readme = "README.md"
 
 [dependencies]

--- a/rinex/Cargo.toml
+++ b/rinex/Cargo.toml
@@ -7,7 +7,7 @@ description = "Package to parse and analyze RINEX data"
 homepage = "https://github.com/gwbres/rinex"
 keywords = ["rinex", "timing", "gps", "glonass", "galileo"]
 categories = ["science", "parsing"]
-edition = "2018"
+edition = "2021"
 readme = "README.md"
 rust-version = "1.61"
 

--- a/rnx2crx/Cargo.toml
+++ b/rnx2crx/Cargo.toml
@@ -7,7 +7,7 @@ description = "RINEX data compressor"
 homepage = "https://github.com/gwbres/rinex"
 keywords = ["rinex", "compression", "crinex"] 
 categories = ["science", "command-line-interface", "command-line-utilities"]
-edition = "2018"
+edition = "2021"
 readme = "README.md"
 
 [dependencies]

--- a/sinex/Cargo.toml
+++ b/sinex/Cargo.toml
@@ -8,7 +8,7 @@ homepage = "https://github.com/gwbres/rinex/sinex"
 repository = "https://github.com/gwbres/rinex/sinex"
 keywords = ["sinex", "timing", "gps", "glonass", "galileo"]
 categories = ["science", "parsing"]
-edition = "2018"
+edition = "2021"
 readme = "README.md"
 
 [features]

--- a/ublox-rnx/Cargo.toml
+++ b/ublox-rnx/Cargo.toml
@@ -7,7 +7,7 @@ description = "Efficient RINEX production from a Ublox GNSS receiver"
 homepage = "https://github.com/gwbres/rinex"
 keywords = ["rinex", "gps", "glonass", "galileo", "timing"]
 categories = ["science", "command-line-interface", "command-line-utilities"]
-edition = "2018"
+edition = "2021"
 readme = "README.md"
 
 [dependencies]


### PR DESCRIPTION
Since we're requiring Rust 1.61 anyway, we might as well use the 2021 edition introduced in 1.56.