### PR TITLE
Add task: automatic building of binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,14 +20,14 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Build dependencies 
-        run: sudo apt-get install libfontconfig1-dev
+        run: sudo apt-get update && sudo apt-get install libfontconfig1-dev
       - name: Compile and release
         uses: rust-build/rust-build.action@v1.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          TOOLCHAIN_VERSION: stable
           RUSTTARGET: ${{ matrix.target }}
-          ARCHIVE_TYPES: ${{ matrix.archive }}
-          SRC_DIR: "rinex-cli"
           EXTRA_FILES: "rinex-cli/README.md LICENSE-APACHE LICENSE-MIT"
+          SRC_DIR: "rinex-cli"
+          ARCHIVE_TYPES: ${{ matrix.archive }}
+          TOOLCHAIN_VERSION: stable

--- a/TODO.md
+++ b/TODO.md
@@ -22,9 +22,10 @@ same combinations on both Wl/Nl sides
 - [ ] compression & decompression benchmarking
 - [ ] IONEX: merge operation
 - [ ] Misc
-  - provide python bindings, similarly to `Hifitime`.  
+  - [ ] provide python bindings, similarly to `Hifitime`.  
    Probably focus on high level and most common methods ?  
    Python bindings should be a crate "feature"
+  - [ ] CI: automatic building of binaries for easy download by non-developers.  
    
   - features are not exposed to the API, we should at least
   exhibit which features exist and what they provide


### PR DESCRIPTION
Adding this because we might easier get feedback from GNSS professionals who are not Rust proficient if they can download a binary of 'rinex-cli'.