### PR TITLE
ignore macOS .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Cargo.lock
 *.jpg
 *.swp
 *.swo
+.DS_Store


### PR DESCRIPTION
These turn up all the time on macOS, so we should ignore them.