### PR TITLE
Use 3.8 instead of latest commit

### DIFF
--- a/rinex/Cargo.toml
+++ b/rinex/Cargo.toml
@@ -35,7 +35,7 @@ geo = { version = "0.23.0", optional = true }
 wkt = { version = "0.10.0", default-features = false, optional = true }
 serde = { version = "1.0", optional = true, default-features = false, features = ["derive"] }
 flate2 = { version = "1.0.24", optional = true, default-features = false, features = ["zlib"] }
-hifitime = { git = "https://github.com/nyx-space/hifitime", features = ["serde", "std"] }
+hifitime = { version = "3.8", features = ["serde", "std"] }
 horrorshow = { version = "0.8" }
 
 [dev-dependencies]


### PR DESCRIPTION
Since our required features in HiFiTime are now in 3.8, we can switch to it instead of using the latest state of the repo.