### PR TITLE
update pretty_env_logger to reduce dependency on atty

### DIFF
--- a/rinex-cli/Cargo.toml
+++ b/rinex-cli/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 
 [dependencies]
 log = "0.4"
-pretty_env_logger = "0.4"
+pretty_env_logger = "0.5"
 clap = { version = "4", features = ["derive", "color"] }
 rand = "0.8"
 serde_json = "1"


### PR DESCRIPTION
`atty` 0.2.14 is vulnerable to Potential unaligned read. A newer version of `pretty_env_logger` replaces this with `is-terminal`.